### PR TITLE
Set correct remote branch for URL

### DIFF
--- a/OpenGithubHelper/open_xcode_file_on_github.rb
+++ b/OpenGithubHelper/open_xcode_file_on_github.rb
@@ -6,8 +6,8 @@ remote = nil
 branch = nil
 repository = nil
 Dir.chdir xcode.project_root do
-  `git branch -r`.strip.lines do |line|
-    if line =~ %r{.+/HEAD -> (.+)/(.+)$}
+  `git branch -r --contains \`git rev-parse @\``.strip.lines do |line|
+    if line =~ %r{(.+)/(.+)$}
       remote = $1
       branch = $2
       break


### PR DESCRIPTION
## Problem

#1 

I'm not really sure how these git command works, but local and remote branches are different in my workspace.

```
$ git branch -r | grep HEAD
  origin/HEAD -> origin/master
$ git branch | grep ^\*
* my-branch
```

So the ruby script uses `master` branch for the GitHub URL path in this case.

## Solution

Get branch name from HEAD commit hash. ( `git branch --contains` )
